### PR TITLE
Enable defined commands to have optional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ def_command :init, dev_commands, 'Set up the development environment' do
   install_bundle
 end
 
-def_command :test, dev_commands, 'Execute automated tests' do |args|
+def_command :test, dev_commands, 'Execute automated tests' do |args = []|
   exec_cmd "bundle exec rake test #{args.join ' '}"
 end
 ```

--- a/_test/go_test.rb
+++ b/_test/go_test.rb
@@ -26,20 +26,40 @@ module GoScript
 
     def test_def_command
       result = nil
-      def_command :test_cmd, ModuleTest.command_group, 'Test command' do |args|
-        result = args.join ' '
+      def_command :test_cmd, ModuleTest.command_group, 'Test command' do
+        result = 'success'
       end
-      test_cmd %w(test cmd args)
-      assert_equal 'test cmd args', result
+      test_cmd
+      assert_equal 'success', result
+    end
+
+    def test_invoke_command_with_optional_argument
+      result = nil
+      def_command(:test_cmd2, ModuleTest.command_group,
+        'Second test command') do |optional_argv = []|
+        result = 'success ' + optional_argv.join(' ')
+      end
+      test_cmd2 %w(foo bar)
+      assert_equal 'success foo bar', result
+    end
+
+    def test_invoke_command_without_optional_argument
+      result = nil
+      def_command(:test_cmd3, ModuleTest.command_group,
+        'Third test command') do |optional_argv = []|
+        result = 'success ' + optional_argv.join(' ')
+      end
+      test_cmd3
+      assert_equal 'success ', result
     end
 
     def test_execute_command
       result = nil
-      def_command(:test_cmd2, ModuleTest.command_group,
-        'Second test command') do |moar, args|
+      def_command(:test_cmd4, ModuleTest.command_group,
+        'Fourth test command') do |moar, args|
         result = [moar, args]
       end
-      execute_command %w(test_cmd2 moar args)
+      execute_command %w(test_cmd4 moar args)
       assert_equal %w(moar args), result
     end
 

--- a/_test/go_test.rb
+++ b/_test/go_test.rb
@@ -8,10 +8,15 @@ require 'stringio'
 
 module GoScript
   class ModuleTest < ::Minitest::Test
-    include GoScript
+    attr_accessor :command_group
 
-    def self.command_group
-      @command_group ||= CommandGroup.add_group 'Test commands'
+    def setup
+      extend GoScript
+      @command_group = CommandGroup.add_group 'Test commands'
+    end
+
+    def teardown
+      CommandGroup.groups.pop
     end
 
     def test_exec_cmd
@@ -26,7 +31,7 @@ module GoScript
 
     def test_def_command
       result = nil
-      def_command :test_cmd, ModuleTest.command_group, 'Test command' do
+      def_command :test_cmd, command_group, 'Test command' do
         result = 'success'
       end
       test_cmd
@@ -35,38 +40,35 @@ module GoScript
 
     def test_invoke_command_with_optional_argument
       result = nil
-      def_command(:test_cmd2, ModuleTest.command_group,
-        'Second test command') do |optional_argv = []|
+      def_command(:test_cmd, command_group,
+        'Test command') do |optional_argv = []|
         result = 'success ' + optional_argv.join(' ')
       end
-      test_cmd2 %w(foo bar)
+      test_cmd %w(foo bar)
       assert_equal 'success foo bar', result
     end
 
     def test_invoke_command_without_optional_argument
       result = nil
-      def_command(:test_cmd3, ModuleTest.command_group,
-        'Third test command') do |optional_argv = []|
+      def_command(:test_cmd, command_group,
+        'Test command') do |optional_argv = []|
         result = 'success ' + optional_argv.join(' ')
       end
-      test_cmd3
+      test_cmd
       assert_equal 'success ', result
     end
 
     def test_execute_command
       result = nil
-      def_command(:test_cmd4, ModuleTest.command_group,
-        'Fourth test command') do |moar, args|
+      def_command :test_cmd, command_group, 'Test command' do |moar, args|
         result = [moar, args]
       end
-      execute_command %w(test_cmd4 moar args)
+      execute_command %w(test_cmd moar args)
       assert_equal %w(moar args), result
     end
 
     def test_execute_command_fail_with_usage_message_if_command_is_nil
       orig_stderr, $stderr = $stderr, StringIO.new
-      # Ensure the 'Test commands' group exists
-      ModuleTest.command_group
       exception = assert_raises(SystemExit) { execute_command [] }
       assert_equal 1, exception.status
       assert $stderr.string.start_with? "Usage: #{$PROGRAM_NAME}"
@@ -77,8 +79,6 @@ module GoScript
 
     def test_execute_command_show_usage_message_when_help_option_specified
       orig_stdout, $stdout = $stdout, StringIO.new
-      # Ensure the 'Test commands' group exists
-      ModuleTest.command_group
       exception = assert_raises(SystemExit) { execute_command %w(-h) }
       assert_equal 0, exception.status
       assert $stdout.string.start_with? "Usage: #{$PROGRAM_NAME}"

--- a/lib/go_script/command_group.rb
+++ b/lib/go_script/command_group.rb
@@ -21,7 +21,7 @@ module GoScript
     end
 
     class <<self
-      attr_reader :groups
+      attr_accessor :groups
       def add_group(description)
         (@groups ||= []).push(new(description)).last
       end

--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -7,7 +7,7 @@ require 'English'
 module GoScript
   def def_command(id, command_group, description, &command_block)
     abort "Command ID must be a symbol: #{id}" unless id.instance_of? Symbol
-    self.class.send :define_method, id, ->(argv) { command_block.call argv }
+    self.class.send :define_method, id, ->(*argv) { command_block.call(*argv) }
     command_group.commands[id] = description
   end
 


### PR DESCRIPTION
Before this change, commands meant to have optional arguments still needed to
be invoked with an empty list, per the initial state of 18F/hub#381.

cc: @afeld @arowla @gboone
