### PR TITLE
Make git_sync_and_deploy more robust

### DIFF
--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -63,9 +63,11 @@ module GoScript
     exec_cmd "#{JEKYLL_BUILD_CMD} #{extra_args}"
   end
 
-  def git_sync_and_deploy(commands)
+  def git_sync_and_deploy(commands, branch: nil)
     exec_cmd 'git stash'
+    exec_cmd "git checkout -b #{branch}" unless branch.nil?
     exec_cmd 'git pull'
+    exec_cmd 'bundle install' if File.exist? 'Gemfile'
     commands.each { |command| exec_cmd command }
   end
 


### PR DESCRIPTION
Now takes an optional `branch` argument to ensure the configured branch is
checked out, and only runs `bundle install` if a Gemfile is present.

cc: @afeld @arowla @gboone
