### PR TITLE
Update template bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ language](https://golang.org). This convention is completely unrelated,
 though it does bear a great deal of resemblance to the Go language's `go`
 command.
 
-### Installation
+### Everyone: install Ruby
 
 Install [the Ruby programming language](https://www.ruby-lang.org/) if it
 isn't already present on your system. We recommend using a Ruby version
 manager such as [rbenv](https://github.com/sstephenson/rbenv) or
 [rvm](https://rvm.io/) to do this.
 
-Install [Bundler](http://bundler.io/) via `gem install bundler`.
+### Project authors: creating a `./go` script
 
-Finally, install the `go_script` gem via `gem install go_script`. You may also
-wish to add it to the [`Gemfile`](http://bundler.io/gemfile.html) of your
-project to ensure version consistency.
+Install the `go_script` gem via `gem install go_script`.
 
-### Creating a `./go` script
+To ensure version consistency for all developers, install
+[Bundler](http://bundler.io/) via `gem install bundler` and add `gem
+'go_script'` to your project's [`Gemfile`](http://bundler.io/gemfile.html).
 
 To create a fresh new `./go` script for your project, run:
 
@@ -49,6 +49,17 @@ $ bundle exec go-script-template > ./go
 $ chmod 700 ./go
 ```
 
+As a bonus, if the project only needs to initialize itself by installing Ruby
+gems from a `Gemfile`, there is no need to define an `init` command. The
+`./go` script will automatically install Bundler and run `bundle install`.
+
+### Project contributors: bootstrapping
+
+If the project already has a `./go` script, you do not need to install
+anything first other than Ruby. Just run the `./go` script. It will
+automatically install the `go_script` gem, either via Bundler (if a `Gemfile`
+is present) or directly using `gem install`.
+
 ### Listing commands
 
 To see the list of available commands for a script: run `./go help` (or one of
@@ -63,9 +74,7 @@ options:
   -v,--version  Show the version of the go_script gem
 
 Development commands
-  init         Set up the development environment
   update_gems  Update Ruby gems
-  update_js    Update JavaScript components
   test         Execute automated tests
   lint         Run style-checking tools
   ci_build     Execute continuous integration build

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ TEST=_test/go_test.rb`.
 dev_commands = GoScript::CommandGroup.add_group 'Development commands'
 
 def_command :init, dev_commands, 'Set up the development environment' do
-  install_bundle
 end
 
 def_command :test, dev_commands, 'Execute automated tests' do |args|

--- a/_test/version_test.rb
+++ b/_test/version_test.rb
@@ -1,22 +1,28 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 require_relative 'test_helper'
-require_relative '../lib/go_script/version'
+require_relative '../lib/go_script/go'
 
 require 'minitest/autorun'
 require 'stringio'
 
 module GoScript
   class VersionTest < ::Minitest::Test
+    def setup
+      extend GoScript
+    end
+
     def test_current_version_ok
-      Version.check_ruby_version RUBY_VERSION
+      check_ruby_version RUBY_VERSION
     end
 
     def test_current_version_fails
       orig_stderr, $stderr = $stderr, StringIO.new
-      assert_raises(SystemExit) do
-        Version.check_ruby_version "#{RUBY_VERSION}.1"
+      exception = assert_raises(SystemExit) do
+        check_ruby_version "#{RUBY_VERSION}.1"
       end
+
+      assert_equal 1, exception.status
       assert_includes($stderr.string,
         "Ruby version #{RUBY_VERSION}.1 or greater is required")
     ensure

--- a/bin/go-script-template
+++ b/bin/go-script-template
@@ -29,9 +29,8 @@ rescue LoadError
   try_command_and_restart 'gem install go_script'
 end
 
-GoScript::Version.check_ruby_version '#{RUBY_VERSION}'
-
 extend GoScript
+check_ruby_version '#{RUBY_VERSION}'
 
 dev_commands = GoScript::CommandGroup.add_group 'Development commands'
 

--- a/bin/go-script-template
+++ b/bin/go-script-template
@@ -35,7 +35,6 @@ check_ruby_version '#{RUBY_VERSION}'
 dev_commands = GoScript::CommandGroup.add_group 'Development commands'
 
 def_command :init, dev_commands, 'Set up the development environment' do
-  install_bundle
 end
 
 def_command :update_gems, dev_commands, 'Update Ruby gems' do |gems|

--- a/bin/go-script-template
+++ b/bin/go-script-template
@@ -8,18 +8,31 @@ puts <<END_OF_TEMPLATE
 
 require 'English'
 
+Dir.chdir File.dirname(__FILE__)
+
+def try_command_and_restart(command)
+  exit $CHILD_STATUS.exitstatus unless system command
+  exec $PROGRAM_NAME, *ARGV
+end
+
+begin
+  require 'bundler/setup' if File.exist? 'Gemfile'
+rescue LoadError
+  try_command_and_restart 'gem install bundler'
+rescue SystemExit
+  try_command_and_restart 'bundle install'
+end
+
 begin
   require 'go_script'
 rescue LoadError
-  puts 'Installing go_script gem...'
-  exit $CHILD_STATUS.exitstatus unless system 'gem install go_script'
+  try_command_and_restart 'gem install go_script'
 end
 
 GoScript::Version.check_ruby_version '#{RUBY_VERSION}'
 
 extend GoScript
 
-BASEDIR = File.dirname(__FILE__)
 dev_commands = GoScript::CommandGroup.add_group 'Development commands'
 
 def_command :init, dev_commands, 'Set up the development environment' do

--- a/go
+++ b/go
@@ -13,16 +13,8 @@ extend GoScript
 BASEDIR = File.dirname(__FILE__)
 dev_commands = GoScript::CommandGroup.add_group 'Development commands'
 
-def_command :init, dev_commands, 'Set up the development environment' do
-  install_bundle
-end
-
 def_command :update_gems, dev_commands, 'Update Ruby gems' do |gems|
   update_gems gems
-end
-
-def_command :update_js, dev_commands, 'Update JavaScript components' do
-  update_node_modules
 end
 
 def_command :test, dev_commands, 'Execute automated tests' do |args|

--- a/go
+++ b/go
@@ -6,9 +6,8 @@ Dir.chdir File.dirname(__FILE__)
 
 require_relative 'lib/go_script'
 
-GoScript::Version.check_ruby_version '2.2.3'
-
 extend GoScript
+check_ruby_version '2.2.3'
 
 BASEDIR = File.dirname(__FILE__)
 dev_commands = GoScript::CommandGroup.add_group 'Development commands'

--- a/go
+++ b/go
@@ -2,12 +2,9 @@
 
 require 'English'
 
-begin
-  require_relative 'lib/go_script'
-rescue LoadError
-  puts 'Installing go_script gem...'
-  exit $CHILD_STATUS.exitstatus unless system 'gem install go_script'
-end
+Dir.chdir File.dirname(__FILE__)
+
+require_relative 'lib/go_script'
 
 GoScript::Version.check_ruby_version '2.2.3'
 

--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -5,6 +5,10 @@ require_relative './version'
 require 'English'
 
 module GoScript
+  def check_ruby_version(min_version)
+    Version.check_ruby_version min_version
+  end
+
   def def_command(id, command_group, description, &command_block)
     abort "Command ID must be a symbol: #{id}" unless id.instance_of? Symbol
     self.class.send :define_method, id, ->(argv) { command_block.call argv }


### PR DESCRIPTION
Now, whether the project uses bundler, or doesn't, or switches back-and-forth, `./go` scripts generated from this template will use the appropriate version of the go_script gem. Also tweaks the gem's own `./go` script. See the commit messages for more details.

cc: @afeld @arowla @gboone
