### PR TITLE
command_group convention; prevent multiple defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,18 +117,18 @@ Commands may take command-line arguments, which are passed in as block
 variables. In the following example, the `./go init` command takes no
 arguments, and the `./go test` command takes an argument list that is appended
 as additional command line arguments to `rake test`. For example, `./go test`
-runs `bundle exec rate test` without any further arguments, while running
+runs `bundle exec rake test` without any further arguments, while running
 `./go test TEST=_test/go_test.rb` ultimately runs `bundle exec rake test
 TEST=_test/go_test.rb`.
 
 ```ruby
-dev_commands = GoScript::CommandGroup.add_group 'Development commands'
+command_group :dev, 'Development commands'
 
-def_command :init, dev_commands, 'Set up the development environment' do
+def_command :init, 'Set up the development environment' do
   install_bundle
 end
 
-def_command :test, dev_commands, 'Execute automated tests' do |args|
+def_command :test, 'Execute automated tests' do |args|
   exec_cmd "bundle exec rake test #{args.join ' '}"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ comprise the `./go` script interface. Its arguments are:
 - *id*: A [Ruby symbol](http://ruby-doc.org/core-2.2.3/Symbol.html)
   (basically, a string starting with `:` with no quotes around it) defining
   the name of the command.
-- *command_group*: A `CommandGroup` instance associated with the command.
 - *description*: A very brief description of the command that appears in the
   usage text.
 
@@ -90,13 +89,27 @@ directives from [`lib/go_script/go.rb`](lib/go_script/go.rb) that may be used
 to define commands, and commands may be built up from other commands defined
 in the `./go` script itself.
 
+**Note:** Command names must be unique. Defining a command with a name already
+used elsewhere will cause the `./go` script to exit with an error message.
+
 #### Command groups
 
-A `CommandGroup` instance clusters a set of commands together.
-`go-script-template` generates a default `CommandGroup` instance called
-`dev_commands`; you are free to edit this definition, or to add additional
-`CommandGroup` instances to organize your individual command definitions and
-affect how they are displayed in the help/usage message.
+Each `command_group` invocation marks the beginning of a set of related
+commands. These groupings organize how commands are displayed in the
+help/usage message.
+
+`go-script-template` generates a default `command_group` called `:dev`. You
+are free to edit this definition, or to add additional `command_group`
+definitions.
+
+**Note:** Command group names must be unique, and command groups cannot be
+re-opened after their initial definition. Defining a command group with a name
+already used elsewhere will cause the `./go` script to exit with an error
+message.
+
+Also, command names must be unique across all command groups. Defining a
+command with the same name as that in another command group will also cause
+the `./go` script to exit with an error message.
 
 #### Command arguments
 

--- a/_test/go_test.rb
+++ b/_test/go_test.rb
@@ -2,21 +2,20 @@
 
 require_relative 'test_helper'
 require_relative '../lib/go_script/go'
+require_relative '../lib/go_script/command_group'
 
 require 'minitest/autorun'
 require 'stringio'
 
 module GoScript
   class ModuleTest < ::Minitest::Test
-    attr_accessor :command_group
-
     def setup
       extend GoScript
-      @command_group = CommandGroup.add_group 'Test commands'
+      command_group :test, 'Test commands'
     end
 
     def teardown
-      CommandGroup.groups.pop
+      CommandGroup.groups.delete :test
     end
 
     def test_exec_cmd
@@ -29,9 +28,20 @@ module GoScript
       end
     end
 
+    def test_command_group_aborts_if_defined_a_second_time
+      orig_stderr, $stderr = $stderr, StringIO.new
+      exception = assert_raises(SystemExit) do
+        command_group :test, 'Test commands'
+      end
+      assert_equal 1, exception.status
+      assert_includes $stderr.string, 'Command group "test" already defined at'
+    ensure
+      $stderr = orig_stderr
+    end
+
     def test_def_command
       result = nil
-      def_command :test_cmd, command_group, 'Test command' do
+      def_command :test_cmd, 'Test command' do
         result = 'success'
       end
       test_cmd
@@ -40,8 +50,7 @@ module GoScript
 
     def test_invoke_command_with_optional_argument
       result = nil
-      def_command(:test_cmd, command_group,
-        'Test command') do |optional_argv = []|
+      def_command :test_cmd, 'Test command' do |optional_argv = []|
         result = 'success ' + optional_argv.join(' ')
       end
       test_cmd %w(foo bar)
@@ -50,8 +59,7 @@ module GoScript
 
     def test_invoke_command_without_optional_argument
       result = nil
-      def_command(:test_cmd, command_group,
-        'Test command') do |optional_argv = []|
+      def_command :test_cmd, 'Test command' do |optional_argv = []|
         result = 'success ' + optional_argv.join(' ')
       end
       test_cmd
@@ -60,11 +68,24 @@ module GoScript
 
     def test_execute_command
       result = nil
-      def_command :test_cmd, command_group, 'Test command' do |moar, args|
+      def_command :test_cmd, 'Test command' do |moar, args|
         result = [moar, args]
       end
       execute_command %w(test_cmd moar args)
       assert_equal %w(moar args), result
+    end
+
+    def test_def_command_aborts_if_defined_a_second_time
+      def_command(:conflict, 'Conflicting command') {}
+      orig_stderr, $stderr = $stderr, StringIO.new
+      command_group :test_group_2, 'Commands should conflict across groups'
+      exception = assert_raises(SystemExit) do
+        def_command(:conflict, 'Conflicting instance') {}
+      end
+      assert_equal 1, exception.status
+      assert_includes $stderr.string, 'Command "conflict" already defined at'
+    ensure
+      $stderr = orig_stderr
     end
 
     def test_execute_command_fail_with_usage_message_if_command_is_nil

--- a/bin/go-script-template
+++ b/bin/go-script-template
@@ -20,25 +20,25 @@ GoScript::Version.check_ruby_version '#{RUBY_VERSION}'
 extend GoScript
 
 BASEDIR = File.dirname(__FILE__)
-dev_commands = GoScript::CommandGroup.add_group 'Development commands'
+command_group :dev, 'Development commands'
 
-def_command :init, dev_commands, 'Set up the development environment' do
+def_command :init, 'Set up the development environment' do
   install_bundle
 end
 
-def_command :update_gems, dev_commands, 'Update Ruby gems' do |gems|
+def_command :update_gems, 'Update Ruby gems' do |gems|
   update_gems gems
 end
 
-def_command :update_js, dev_commands, 'Update JavaScript components' do
+def_command :update_js, 'Update JavaScript components' do
   update_node_modules
 end
 
-def_command :test, dev_commands, 'Execute automated tests' do |args|
+def_command :test, 'Execute automated tests' do |args|
   exec_cmd "bundle exec rake test \#{args.join ' '}"
 end
 
-def_command :lint, dev_commands, 'Run style-checking tools' do |files|
+def_command :lint, 'Run style-checking tools' do |files|
   files = files.group_by { |f| File.extname f }
   lint_ruby files['.rb']
   lint_javascript BASEDIR, files['.js']

--- a/go
+++ b/go
@@ -14,35 +14,31 @@ GoScript::Version.check_ruby_version '2.2.3'
 extend GoScript
 
 BASEDIR = File.dirname(__FILE__)
-dev_commands = GoScript::CommandGroup.add_group 'Development commands'
+command_group :dev, 'Development commands'
 
-def_command :init, dev_commands, 'Set up the development environment' do
+def_command :init, 'Set up the development environment' do
   install_bundle
 end
 
-def_command :update_gems, dev_commands, 'Update Ruby gems' do |gems|
+def_command :update_gems, 'Update Ruby gems' do |gems|
   update_gems gems
 end
 
-def_command :update_js, dev_commands, 'Update JavaScript components' do
-  update_node_modules
-end
-
-def_command :test, dev_commands, 'Execute automated tests' do |args|
+def_command :test, 'Execute automated tests' do |args|
   exec_cmd "bundle exec rake test #{args.join ' '}"
 end
 
-def_command :lint, dev_commands, 'Run style-checking tools' do |files|
+def_command :lint, 'Run style-checking tools' do |files|
   files = files.group_by { |f| File.extname f }
   lint_ruby files['.rb']
 end
 
-def_command :ci_build, dev_commands, 'Execute continuous integration build' do
+def_command :ci_build, 'Execute continuous integration build' do
   test []
   exec_cmd 'bundle exec rake build'
 end
 
-def_command :release, dev_commands, 'Test, build, and release a new gem' do
+def_command :release, 'Test, build, and release a new gem' do
   test []
   exec_cmd 'bundle exec rake release'
 end

--- a/lib/go_script.rb
+++ b/lib/go_script.rb
@@ -1,5 +1,4 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 require_relative './go_script/go'
-require_relative './go_script/command_group'
 require_relative './go_script/version'

--- a/lib/go_script/command_group.rb
+++ b/lib/go_script/command_group.rb
@@ -1,36 +1,84 @@
 # Author: Mike Bland <michael.bland@gsa.gov>
 
+require 'English'
+require 'pathname'
+
 module GoScript
+  class Command
+    attr_reader :description, :path, :lineno
+
+    def initialize(description, path, lineno)
+      @description = description
+      @path = path
+      @lineno = lineno
+    end
+  end
+
   # Groups a set of commands by common function.
   class CommandGroup
-    attr_accessor :description, :commands
+    attr_reader :description, :path, :lineno
+    attr_accessor :commands
     private_class_method :new
 
-    # @param description [String] short description of the group
-    def initialize(description)
+    def initialize(description, path, lineno)
       @description = description
+      @path = path
+      @lineno = lineno
       @commands = {}
     end
 
     def to_s
       padding = (commands.keys.max_by(&:size) || '').size + 2
-      command_descriptions = commands.map do |name, desc|
-        format "  %-#{padding}s#{desc}", name
+      command_descriptions = commands.map do |name, command|
+        format "  %-#{padding}s#{command.description}", name
       end
       ["\n#{@description}"].concat(command_descriptions).join("\n")
     end
 
+    def include_command?(command_symbol)
+      commands.keys.include? command_symbol
+    end
+
     class <<self
-      attr_accessor :groups
-      def add_group(description)
-        (@groups ||= []).push(new(description)).last
+      def groups
+        @groups ||= {}
+      end
+
+      def location_path(target_path)
+        @base_path ||= Pathname.new(
+          File.dirname(File.expand_path $PROGRAM_NAME))
+        Pathname.new(File.expand_path target_path).relative_path_from @base_path
+      end
+
+      def check_not_defined(collection, label, key, path, lineno)
+        return unless (existing = collection[key])
+        previous = location_path existing.path
+        current = location_path path
+        prefix = previous == current ? 'line ' : previous + ':'
+        abort "#{current}:#{lineno}: #{label} \"#{key}\" " \
+          "already defined at #{prefix}#{existing.lineno}"
+      end
+
+      def add_group(group_symbol, description, path, lineno)
+        check_not_defined groups, 'Command group', group_symbol, path, lineno
+        groups[group_symbol] = new description, path, lineno
+      end
+
+      def command_defined?(command)
+        groups.values.each { |g| return true if g.include_command? command }
+      end
+
+      def add_command(command, group_symbol, description, path, lineno)
+        groups.values.each do |group|
+          check_not_defined group.commands, 'Command', command, path, lineno
+        end
+        groups[group_symbol].commands[command] = Command.new(
+          description, path, lineno)
       end
 
       def command(command_sym)
-        if (groups || []).flat_map { |g| g.commands.keys }.include? command_sym
-          return command_sym
-        end
-        puts "Unknown option or command: #{command_sym}"
+        return command_sym if command_defined? command_sym
+        $stderr.puts "Unknown option or command: #{command_sym}"
         usage exitstatus: 1
       end
 
@@ -43,7 +91,7 @@ options:
   -h,--help     Show this help
   -v,--version  Show the version of the go_script gem
 END_OF_USAGE
-        (groups || []).each { |group| output_stream.puts group }
+        (groups.values || []).each { |group| output_stream.puts group }
         exit exitstatus
       end
     end


### PR DESCRIPTION
Depends on #1.

Rather than have to specify a command group with each command, now calling
command_group establishes a context for all commands that follow, until
command_group is invoked for a new group.

Also adds robust checks to prevent a command group or an individual command
from being defined more than once, with error messages pinpointing the
location of each definition.

cc: @afeld @arowla @gboone
