### PR TITLE
Abort if go_script not in Gemfile

### DIFF
--- a/bin/go-script-template
+++ b/bin/go-script-template
@@ -26,7 +26,8 @@ end
 begin
   require 'go_script'
 rescue LoadError
-  try_command_and_restart 'gem install go_script'
+  try_command_and_restart 'gem install go_script' unless File.exist? 'Gemfile'
+  abort "Please add \\\"gem 'go_script'\\\" to your Gemfile"
 end
 
 extend GoScript


### PR DESCRIPTION
Found out that when adding a `./go` script to a project for the first time, if
that project has a Gemfile, the `./go` script will enter a loop whereby it
installs go_script to the system gems over and over. This change causes the
script to abort with instructions, since it's up to the project developer to
determine how exactly the go_script gem should be included (e.g. as part of a
'development' group).

cc: @arowla @afeld @gboone
