### PR TITLE
Clear RUBYOPT when executing commands, restarting

### DIFF
--- a/bin/go-script-template
+++ b/bin/go-script-template
@@ -12,7 +12,7 @@ Dir.chdir File.dirname(__FILE__)
 
 def try_command_and_restart(command)
   exit $CHILD_STATUS.exitstatus unless system command
-  exec RbConfig.ruby, *[$PROGRAM_NAME].concat(ARGV)
+  exec({ 'RUBYOPT' => nil }, RbConfig.ruby, *[$PROGRAM_NAME].concat(ARGV))
 end
 
 begin

--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -40,16 +40,7 @@ module GoScript
   end
 
   def exec_cmd(cmd)
-    exit $CHILD_STATUS.exitstatus unless system cmd
-  end
-
-  def install_bundle
-    begin
-      require 'bundler'
-    rescue LoadError
-      exec_cmd 'gem install bundler'
-    end
-    exec_cmd 'bundle install'
+    exit $CHILD_STATUS.exitstatus unless system({ 'RUBYOPT' => nil }, cmd)
   end
 
   def update_gems(gems = '')


### PR DESCRIPTION
When running commands after the Gemfile is updated, `bundle` will not update
the load path if RUBYOPT is already set, leading to restart loops in
`try_command_and_restart` and command program crashes.

Also removes the vestigal `install_bundle` command, since the template code
now handles bundler installation.

cc: @arowla @gboone 
