### PR TITLE
exec_cmd: redirect stderr to stdout

### DIFF
--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -40,7 +40,8 @@ module GoScript
   end
 
   def exec_cmd(cmd)
-    exit $CHILD_STATUS.exitstatus unless system({ 'RUBYOPT' => nil }, cmd)
+    exit $CHILD_STATUS.exitstatus unless system(
+      { 'RUBYOPT' => nil }, cmd, err: :out)
   end
 
   def update_gems(gems = '')

--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -45,6 +45,7 @@ module GoScript
     if $CHILD_STATUS.exitstatus.nil?
       $stderr.puts "could not run command: #{cmd}"
       $stderr.puts "(Check syslog for possible `Out of memory` error?)"
+      exit 1
     else
       exit $CHILD_STATUS.exitstatus unless status
     end

--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -40,8 +40,14 @@ module GoScript
   end
 
   def exec_cmd(cmd)
-    exit $CHILD_STATUS.exitstatus unless system(
+    status = system(
       { 'RUBYOPT' => nil }, cmd, err: :out)
+    if $CHILD_STATUS.exitstatus.nil?
+      $stderr.puts "could not run command: #{cmd}"
+      $stderr.puts "(Check syslog for possible `Out of memory` error?)"
+    else
+      exit $CHILD_STATUS.exitstatus unless status
+    end
   end
 
   def update_gems(gems = '')


### PR DESCRIPTION
See 18F/18f.gsa.gov#1443 for context. Apparently several git subcommands will write to standard error in some cases, which caused SIGPIPE errors when running under [`forever`](https://github.com/foreverjs/forever).

cc: @afeld @ccostino @ertzeid @gboone 
