### PR TITLE
Account for `nil` in `$CHILD_STATUS.exitstatus`

### DIFF
--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -45,6 +45,7 @@ module GoScript
     if $CHILD_STATUS.exitstatus.nil?
       $stderr.puts "could not run command: #{cmd}"
       $stderr.puts "(Check syslog for possible `Out of memory` error?)"
+      exit 1
     else
       exit $CHILD_STATUS.exitstatus unless status
     end

--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -40,8 +40,14 @@ module GoScript
   end
 
   def exec_cmd(cmd)
-    exit $CHILD_STATUS.exitstatus unless system(
+    status = system(
       { 'RUBYOPT' => nil }, cmd, err: :out)
+    if $CHILD_STATUS.exitstatus.nil?
+      $stderr.puts "could not run command: #{cmd}"
+      $stderr.puts "(Check syslog for possible `Out of memory` error?)"
+    else
+      exit $CHILD_STATUS.exitstatus unless status
+    end
   end
 
   def update_gems(gems = '')


### PR DESCRIPTION
An OOM Killer crash as the command runs (and possibly other problems)
creates an `exitstatus` of `nil`.  This was causing very cryptic

```
in `exit': no implicit conversion from nil to integer (TypeError)
```

errors.  With the patch, the output is less confusing.
