### PR TITLE
Fix build_jekyll failures on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# ignore artifacts from `bundle install --path=...`, such as those generated
+# by Travis.
+.bundle
+vendor

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## The `./go` script: a unified development environment interface.
+## The `./go` script: a unified development environment interface
 
 A `./go` script aims to abstract away all of the steps needed to develop (and
 sometimes deploy) a software project. It is a replacement for READMEs and

--- a/_test/bundle_test.rb
+++ b/_test/bundle_test.rb
@@ -1,0 +1,67 @@
+require_relative 'test_helper'
+require_relative '../lib/go_script'
+
+require 'fileutils'
+require 'minitest/autorun'
+
+module GoScript
+  class BundleTest < ::Minitest::Test
+    attr_reader :testdir, :go_script, :gemfile, :this_gem, :env
+
+    def setup
+      @testdir = Dir.mktmpdir
+      @go_script = File.join(testdir, 'go')
+      @gemfile = File.join(testdir, 'Gemfile')
+      @this_gem = File.dirname(File.dirname(__FILE__))
+      @env = {
+        'BUNDLE_BIN_PATH' => nil,
+        'BUNDLE_GEMFILE' => nil,
+        'RUBYOPT' => nil,
+      }
+
+      File.write(gemfile, [
+        'source \'https://rubygems.org\'',
+        'gem \'jekyll\'',
+        "gem 'go_script', path: '#{this_gem}'\n",
+      ].join("\n"))
+    end
+
+    def teardown
+      FileUtils.remove_entry(testdir)
+    end
+
+    def create_script(commands)
+      open(go_script, 'w') do |script|
+        script.puts(GoScript::Template.preamble)
+        script.puts(commands)
+        script.puts(GoScript::Template.end)
+      end
+      FileUtils.chmod(0700, go_script)
+    end
+
+    def create_jekyll_script
+      create_script([
+        'command_group :dev, \'Development commands\'',
+        'def_command :build, \'Build the site\' do |args|',
+        '  build_jekyll(args)',
+        'end',
+      ].join("\n"))
+    end
+
+    def test_create_script
+      create_script('')
+      assert(system(env, go_script, '-h', out: '/dev/null'))
+    end
+
+    def test_bundler
+      create_jekyll_script
+      assert(system(env, go_script, 'build', '--help', out: '/dev/null'))
+    end
+
+    def test_bundler_with_path_argument
+      system(env, "cd #{testdir} && bundle install --path=vendor/bundle")
+      create_jekyll_script
+      assert(system(env, go_script, 'build', '--help'))
+    end
+  end
+end

--- a/_test/bundle_test.rb
+++ b/_test/bundle_test.rb
@@ -8,6 +8,7 @@ module GoScript
   class BundleTest < ::Minitest::Test
     attr_reader :testdir, :go_script, :gemfile, :this_gem, :env
 
+    # rubocop:disable MethodLength
     def setup
       @testdir = Dir.mktmpdir
       @go_script = File.join(testdir, 'go')
@@ -25,6 +26,7 @@ module GoScript
         "gem 'go_script', path: '#{this_gem}'\n",
       ].join("\n"))
     end
+    # rubocop:enable MethodLength
 
     def teardown
       FileUtils.remove_entry(testdir)

--- a/bin/go-script-template
+++ b/bin/go-script-template
@@ -3,58 +3,6 @@
 
 require_relative '../lib/go_script'
 
-puts <<END_OF_TEMPLATE
-#! /usr/bin/env ruby
-
-require 'English'
-
-Dir.chdir File.dirname(__FILE__)
-
-def try_command_and_restart(command)
-  exit $CHILD_STATUS.exitstatus unless system command
-  exec({ 'RUBYOPT' => nil }, RbConfig.ruby, *[$PROGRAM_NAME].concat(ARGV))
-end
-
-begin
-  require 'bundler/setup' if File.exist? 'Gemfile'
-rescue LoadError
-  try_command_and_restart 'gem install bundler'
-rescue SystemExit
-  try_command_and_restart 'bundle install'
-end
-
-begin
-  require 'go_script'
-rescue LoadError
-  try_command_and_restart 'gem install go_script' unless File.exist? 'Gemfile'
-  abort "Please add \\\"gem 'go_script'\\\" to your Gemfile"
-end
-
-extend GoScript
-check_ruby_version '#{RUBY_VERSION}'
-
-command_group :dev, 'Development commands'
-
-def_command :init, 'Set up the development environment' do
-end
-
-def_command :update_gems, 'Update Ruby gems' do |gems|
-  update_gems gems
-end
-
-def_command :update_js, 'Update JavaScript components' do
-  update_node_modules
-end
-
-def_command :test, 'Execute automated tests' do |args|
-  exec_cmd "bundle exec rake test \#{args.join ' '}"
-end
-
-def_command :lint, 'Run style-checking tools' do |files|
-  files = files.group_by { |f| File.extname f }
-  lint_ruby files['.rb']  # uses rubocop
-  lint_javascript Dir.pwd, files['.js']  # uses node_modules/jshint
-end
-
-execute_command ARGV
-END_OF_TEMPLATE
+puts GoScript::Template.preamble
+puts GoScript::Template.standard_dev_commands
+puts GoScript::Template.end

--- a/go_script.gemspec
+++ b/go_script.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'rubocop'
+  # We need Jekyll for _test/bundler_test.rb
+  s.add_development_dependency 'jekyll'
 end

--- a/lib/go_script.rb
+++ b/lib/go_script.rb
@@ -1,4 +1,5 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 require_relative './go_script/go'
+require_relative './go_script/template'
 require_relative './go_script/version'

--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -44,7 +44,7 @@ module GoScript
       { 'RUBYOPT' => nil }, cmd, err: :out)
     if $CHILD_STATUS.exitstatus.nil?
       $stderr.puts "could not run command: #{cmd}"
-      $stderr.puts "(Check syslog for possible `Out of memory` error?)"
+      $stderr.puts '(Check syslog for possible `Out of memory` error?)'
       exit 1
     else
       exit $CHILD_STATUS.exitstatus unless status
@@ -90,10 +90,11 @@ module GoScript
   end
 
   def git_sync_and_deploy(commands, branch: nil)
-    exec_cmd 'git stash'
-    exec_cmd "git checkout -b #{branch}" unless branch.nil?
-    exec_cmd 'git pull'
-    exec_cmd 'bundle install' if File.exist? 'Gemfile'
+    exec_cmd 'git fetch origin #{branch}'
+    exec_cmd 'git clean -f'
+    exec_cmd "git reset --hard #{branch.nil? ? 'HEAD' : 'origin/' + branch}"
+    exec_cmd 'git submodule --sync --recursive'
+    exec_cmd 'git submodule update --init --recursive'
     commands.each { |command| exec_cmd command }
   end
 

--- a/lib/go_script/go.rb
+++ b/lib/go_script/go.rb
@@ -64,8 +64,8 @@ module GoScript
     exec_cmd 'npm install'
   end
 
-  JEKYLL_BUILD_CMD = 'bundle exec jekyll build --trace'
-  JEKYLL_SERVE_CMD = 'bundle exec jekyll serve -w --trace'
+  JEKYLL_BUILD_CMD = 'jekyll build --trace'
+  JEKYLL_SERVE_CMD = 'jekyll serve -w --trace'
 
   def args_to_string(args)
     args ||= ''

--- a/lib/go_script/template.rb
+++ b/lib/go_script/template.rb
@@ -1,5 +1,6 @@
 module GoScript
   class Template
+    # rubocop:disable MethodLength
     def self.preamble
       <<END_OF_PREAMBLE
 #! /usr/bin/env ruby
@@ -33,7 +34,9 @@ check_ruby_version '#{RUBY_VERSION}'
 
 END_OF_PREAMBLE
     end
+    # rubocop:enable MethodLength
 
+    # rubocop:disable MethodLength
     def self.standard_dev_commands
       <<END_STANDARD_DEV_COMMANDS
 command_group :dev, 'Development commands'
@@ -61,6 +64,7 @@ end
 
 END_STANDARD_DEV_COMMANDS
     end
+    # rubocop:enable MethodLength
 
     def self.end
       "execute_command ARGV\n"

--- a/lib/go_script/template.rb
+++ b/lib/go_script/template.rb
@@ -1,0 +1,69 @@
+module GoScript
+  class Template
+    def self.preamble
+      <<END_OF_PREAMBLE
+#! /usr/bin/env ruby
+
+require 'English'
+
+Dir.chdir File.dirname(__FILE__)
+
+def try_command_and_restart(command)
+  exit $CHILD_STATUS.exitstatus unless system command
+  exec({ 'RUBYOPT' => nil }, RbConfig.ruby, *[$PROGRAM_NAME].concat(ARGV))
+end
+
+begin
+  require 'bundler/setup' if File.exist? 'Gemfile'
+rescue LoadError
+  try_command_and_restart 'gem install bundler'
+rescue SystemExit
+  try_command_and_restart 'bundle install'
+end
+
+begin
+  require 'go_script'
+rescue LoadError
+  try_command_and_restart 'gem install go_script' unless File.exist? 'Gemfile'
+  abort "Please add \\\"gem 'go_script'\\\" to your Gemfile"
+end
+
+extend GoScript
+check_ruby_version '#{RUBY_VERSION}'
+
+END_OF_PREAMBLE
+    end
+
+    def self.standard_dev_commands
+      <<END_STANDARD_DEV_COMMANDS
+command_group :dev, 'Development commands'
+
+def_command :init, 'Set up the development environment' do
+end
+
+def_command :update_gems, 'Update Ruby gems' do |gems|
+  update_gems gems
+end
+
+def_command :update_js, 'Update JavaScript components' do
+  update_node_modules
+end
+
+def_command :test, 'Execute automated tests' do |args|
+  exec_cmd "bundle exec rake test \#{args.join ' '}"
+end
+
+def_command :lint, 'Run style-checking tools' do |files|
+  files = files.group_by { |f| File.extname f }
+  lint_ruby files['.rb']  # uses rubocop
+  lint_javascript Dir.pwd, files['.js']  # uses node_modules/jshint
+end
+
+END_STANDARD_DEV_COMMANDS
+    end
+
+    def self.end
+      "execute_command ARGV\n"
+    end
+  end
+end


### PR DESCRIPTION
Closes #16. Basically, since the `./go` script should already invoke `require 'bundler/setup'`, running Jekyll with `bundle exec` proves unnecessary. The test_bundler_with_path_argument test case recreates the original failure faithfully, and validates the fix.

Also updates `git_sync_and_deploy` a la 18F/pages-server#19.

cc: @afeld @ccostino @jcscottiii @harrisj @rogeruiz @juliaelman 
